### PR TITLE
add download links for 100 TB dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Sample Data Generator 
-‘BenchmarkLogGenerator’ is a command line tool to generate sample trace and error logs data. This data can be used for proof of concepts or performance benchmarking scenarios.
-This tool supports following configurable command line parameters –
+BenchmarkLogGenerator is a command line tool to generate sample trace and error logs data. This data can be used for proof of concepts or performance benchmarking scenarios. This tool supports following configurable command line parameters:
 1. **-output**: This is the location where output should be written to. 
 Supported values are: LocalDisk, AzureStorage, EventHub
 2. **-size**: The data size to be generated. 
@@ -58,7 +57,19 @@ Default value is OneGB
 
     `az batch job create --template generator-job.json`
 
+## Download 100 TB dataset
+Given that generating the 100 TB dataset takes non-trivial amount of time and resources, we host the generated files publicly on Azure Storage to allow customers run their own benchmarks without delay. We kindly ask that you access the files from compute resources in West Europe, where the files are hosted, to achieve optimal performance and reduce egress charges.
 
+* <https://logsbenchmark00.blob.core.windows.net/logsbenchmark-hundredtb-p0?sp=rl&st=2022-08-01T00:00:00Z&se=2030-01-01T00:00:00Z&spr=https&sv=2021-06-08&sr=c&sig=4hPD07%2F8Mt9kqktmVpAcy%2BJJk1suqFOML3yS5UqGCz0%3D>
+* <https://logsbenchmark01.blob.core.windows.net/logsbenchmark-hundredtb-p1?sp=rl&st=2022-08-01T00:00:00Z&se=2030-01-01T00:00:00Z&spr=https&sv=2021-06-08&sr=c&sig=t0c3M%2BUzb4x18cDQqqE5zxrZXcTI9bOctkztiAzfT3k%3D>
+* <https://logsbenchmark02.blob.core.windows.net/logsbenchmark-hundredtb-p2?sp=rl&st=2022-08-01T00:00:00Z&se=2030-01-01T00:00:00Z&spr=https&sv=2021-06-08&sr=c&sig=liAlXYzAg8i0w1L7%2B3V%2Bd7laSNaC68xD3zelq8WZNuk%3D>
+* <https://logsbenchmark03.blob.core.windows.net/logsbenchmark-hundredtb-p3?sp=rl&st=2022-08-01T00:00:00Z&se=2030-01-01T00:00:00Z&spr=https&sv=2021-06-08&sr=c&sig=ErV7E6ItUOR5RyjygA%2FNBmnShJn%2BgHM%2Bo4p8bvA1IRw%3D>
+* <https://logsbenchmark04.blob.core.windows.net/logsbenchmark-hundredtb-p4?sp=rl&st=2022-08-01T00:00:00Z&se=2030-01-01T00:00:00Z&spr=https&sv=2021-06-08&sr=c&sig=Y6NPOqg%2BAjLRp7h7IpOlcNDbltfY6aHzTYkjUUPE3xw%3D>
+* <https://logsbenchmark05.blob.core.windows.net/logsbenchmark-hundredtb-p5?sp=rl&st=2022-08-01T00:00:00Z&se=2030-01-01T00:00:00Z&spr=https&sv=2021-06-08&sr=c&sig=uSk0dYlLoJ0nU6PoZInITxoin0%2B%2FY%2FQnQwXZe0flIfg%3D>
+* <https://logsbenchmark06.blob.core.windows.net/logsbenchmark-hundredtb-p6?sp=rl&st=2022-08-01T00:00:00Z&se=2030-01-01T00:00:00Z&spr=https&sv=2021-06-08&sr=c&sig=qG33WutBzKYaLp%2BYO%2BREzl9vTxHvoGbtaU1fyr0asno%3D>
+* <https://logsbenchmark07.blob.core.windows.net/logsbenchmark-hundredtb-p7?sp=rl&st=2022-08-01T00:00:00Z&se=2030-01-01T00:00:00Z&spr=https&sv=2021-06-08&sr=c&sig=%2FQrpUmZLOwpGRv8PV8tNwjJ8GSKY2G%2BToaAX0vy%2FYV4%3D>
+* <https://logsbenchmark08.blob.core.windows.net/logsbenchmark-hundredtb-p8?sp=rl&st=2022-08-01T00:00:00Z&se=2030-01-01T00:00:00Z&spr=https&sv=2021-06-08&sr=c&sig=iX%2BL4ALwKFeo5X564%2BRmZ76HjXjCYsy7IvoowXTqMR0%3D>
+* <https://logsbenchmark09.blob.core.windows.net/logsbenchmark-hundredtb-p9?sp=rl&st=2022-08-01T00:00:00Z&se=2030-01-01T00:00:00Z&spr=https&sv=2021-06-08&sr=c&sig=MQsfzOlpZnYyxs%2B3CJP5v1vAfYydjKAO7sHruT8kZyY%3D>
 
 
 # Contributing


### PR DESCRIPTION
As agreed, Kusto team will host 100 TB dataset publicly.

Publishing the URLs with SAS keys, which have read and list permissions, is intentional - please help override if blocked by security policy.